### PR TITLE
update office365 to use prompt=login params

### DIFF
--- a/office365_client.js
+++ b/office365_client.js
@@ -4,26 +4,27 @@ import { Session } from 'meteor/session';
 
 Office365 = {};
 
-Office365.requestCredential = function(options, credentialRequestCompleteCallback) {
+Office365.requestCredential = function (options, credentialRequestCompleteCallback) {
 
-  Session.set("redirectUrl", options.redirectUrl );
 
   if (!credentialRequestCompleteCallback && typeof options === 'function') {
     credentialRequestCompleteCallback = options;
     options = {};
   }
 
-  const config = ServiceConfiguration.configurations.findOne({service: 'office365'});
+  const config = ServiceConfiguration.configurations.findOne({ service: 'office365' });
 
   if (!config) {
     credentialRequestCompleteCallback && credentialRequestCompleteCallback(new ServiceConfiguration.ConfigError());
     return;
   }
+  if (!options) options = {};
+  Session.set("redirectUrl", options.redirectUrl);
 
   const credentialToken = Random.secret();
 
-  if (!options) options = {};
   if (!options.requestPermissions) options.requestPermissions = config.permissions;
+  if (!options.loginUrlParameters) options.loginUrlParameters = {};
 
   const scope = options.requestPermissions || ['offline_access', 'user.read'];
   const flatScope = _.map(scope, encodeURIComponent).join('%20');
@@ -31,9 +32,9 @@ Office365.requestCredential = function(options, credentialRequestCompleteCallbac
   const loginStyle = OAuth._loginStyle('office365', config, options);
 
   // The Microsoft Office 365 Application not allow the parameter "close" at redirect URLs
-  const redirectUri = `${Meteor.absoluteUrl()}api/office365-auth`; //OAuth._redirectUri('office365', config).replace('?close', '');
-
-  const loginUrl = `https://login.microsoftonline.com/${ config.tenant || 'common' }/oauth2/v2.0/authorize?client_id=${ config.clientId }&response_type=code&redirect_uri=${ redirectUri }&response_mode=query&scope=${ flatScope }&state=${ OAuth._stateParam(loginStyle, credentialToken, redirectUri) }`;
+  const redirectUri = `${Meteor.absoluteUrl()}api/office365-auth`; // OAuth._redirectUri('office365', config).replace('?close', '');
+  const forcePrompt = options.loginUrlParameters.prompt ? `&prompt=${options.loginUrlParameters.prompt}` : ``
+  const loginUrl = `https://login.microsoftonline.com/${config.tenant || 'common'}/oauth2/v2.0/authorize?client_id=${config.clientId}&response_type=code&redirect_uri=${redirectUri}&response_mode=query&scope=${flatScope}&state=${OAuth._stateParam(loginStyle, credentialToken, redirectUri)}` + forcePrompt;
 
   OAuth.launchLogin({
     loginService: 'office365',


### PR DESCRIPTION
Based on answer from here:

https://stackoverflow.com/questions/28066886/force-re-login-for-oauth2-office365-rest-api

Also related: https://github.com/sudotong/meteor-accounts-office365/pull/1